### PR TITLE
Specify a folder name in the file path of ScriptableSingleton

### DIFF
--- a/UnityNaturalMCPServer/Editor/MCPSetting.cs
+++ b/UnityNaturalMCPServer/Editor/MCPSetting.cs
@@ -2,7 +2,7 @@
 
 namespace UnityNaturalMCP.Editor
 {
-    [FilePath("UnityNaturalMCPSetting.asset", FilePathAttribute.Location.ProjectFolder)]
+    [FilePath("ProjectSettings/UnityNaturalMCPSetting.asset", FilePathAttribute.Location.ProjectFolder)]
     public sealed class MCPSetting : ScriptableSingleton<MCPSetting>
     {
         public string ipAddress = "localhost";


### PR DESCRIPTION
ScriptableSingletonのFilePathアトリビュートでProjectFolderを指定する場合は、ファイル名だけでなくフォルダ名も含める必要があるようです。
手元の環境ではこの修正で該当エラーは消えました。

* fix notargs/UnityNaturalMCP#44

> 参考 https://discussions.unity.com/t/scriptablesingleton-cant-save-argumentexception-path-cannot-be-the-empty-string-or-all-whitespace/1527878