### PR TITLE
Fix failed tests format to JSON

### DIFF
--- a/UnityNaturalMCPServer/Editor/McpTools/RunTestsTool/TestResultCollector.cs
+++ b/UnityNaturalMCPServer/Editor/McpTools/RunTestsTool/TestResultCollector.cs
@@ -80,7 +80,7 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
         {
             while (_runFinished == false && !cancellationToken.IsCancellationRequested)
             {
-                await Task.Delay(200, cancellationToken);
+                await Task.Delay(500, cancellationToken);
             }
 
             return _abortMessage ?? _testResults.ToJson();

--- a/UnityNaturalMCPServer/Editor/McpTools/RunTestsTool/TestResultCollector.cs
+++ b/UnityNaturalMCPServer/Editor/McpTools/RunTestsTool/TestResultCollector.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using UnityEditor.TestTools.TestRunner.Api;
@@ -10,7 +11,9 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
     /// </summary>
     public class TestResultCollector : IErrorCallbacks
     {
+        [SuppressMessage("ReSharper", "InconsistentNaming")]
         internal readonly TestResults _testResults = new TestResults();
+
         private string _abortMessage;
         private bool _runFinished;
 
@@ -44,7 +47,7 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
             {
                 case TestStatus.Failed:
                     _testResults.failCount++;
-                    _testResults.failedTests.Add(CreateFailedTestString(result));
+                    _testResults.failedTests.Add(new FailedTestResult(result));
                     break;
                 case TestStatus.Passed:
                     _testResults.passCount++;
@@ -54,16 +57,11 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
                     break;
                 case TestStatus.Inconclusive:
                     _testResults.inconclusiveCount++;
-                    _testResults.failedTests.Add(CreateFailedTestString(result));
+                    _testResults.failedTests.Add(new FailedTestResult(result));
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-        }
-
-        private static string CreateFailedTestString(ITestResultAdaptor result)
-        {
-            return $"Test {result.FullName} is failed with message: {result.Message}\n{result.StackTrace}";
         }
 
         /// <inheritdoc/>
@@ -82,7 +80,7 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
         {
             while (_runFinished == false && !cancellationToken.IsCancellationRequested)
             {
-                await Task.Delay(500, cancellationToken);
+                await Task.Delay(200, cancellationToken);
             }
 
             return _abortMessage ?? _testResults.ToJson();

--- a/UnityNaturalMCPServer/Editor/McpTools/RunTestsTool/TestResults.cs
+++ b/UnityNaturalMCPServer/Editor/McpTools/RunTestsTool/TestResults.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
+using UnityEditor.TestTools.TestRunner.Api;
 
 namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
 {
@@ -31,7 +32,7 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
         /// Failed or inconclusive tests.
         /// </summary>
         [SuppressMessage("ReSharper", "CollectionNeverQueried.Global")]
-        public List<string> failedTests { get; } = new List<string>();
+        public List<FailedTestResult> failedTests { get; } = new List<FailedTestResult>();
 
         /// <summary>
         /// Returns true if all tests passed.
@@ -45,6 +46,31 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
         public string ToJson()
         {
             return JsonSerializer.Serialize(this);
+        }
+    }
+
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    public class FailedTestResult
+    {
+        public string name { get; }
+        public string fullName { get; }
+        public string resultState { get; }
+        public string testStatus { get; }
+        public double duration { get; }
+        public string message { get; }
+        public string stackTrace { get; }
+        public string output { get; }
+
+        public FailedTestResult(ITestResultAdaptor result)
+        {
+            name = result.Name;
+            fullName = result.FullName;
+            resultState = result.ResultState;
+            testStatus = result.TestStatus.ToString();
+            duration = result.Duration;
+            message = result.Message;
+            stackTrace = result.StackTrace;
+            output = result.Output;
         }
     }
 }

--- a/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/FakeTestResultAdaptor.cs
+++ b/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/FakeTestResultAdaptor.cs
@@ -16,11 +16,11 @@ namespace UnityNaturalMCP.Tests.McpTools.RunTestsTool
         }
 
         public ITestAdaptor Test { get; }
-        public string Name { get; }
+        public string Name { get; set; }
         public string FullName { get; set; }
-        public string ResultState { get; }
+        public string ResultState { get; set; }
         public TestStatus TestStatus { get; set; }
-        public double Duration { get; }
+        public double Duration { get; set; }
         public DateTime StartTime { get; }
         public DateTime EndTime { get; }
         public string Message { get; set; }
@@ -32,6 +32,6 @@ namespace UnityNaturalMCP.Tests.McpTools.RunTestsTool
         public int InconclusiveCount { get; }
         public bool HasChildren { get; set; }
         public IEnumerable<ITestResultAdaptor> Children { get; }
-        public string Output { get; }
+        public string Output { get; set; }
     }
 }

--- a/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/TestResultCollectorTest.cs
+++ b/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/TestResultCollectorTest.cs
@@ -61,9 +61,13 @@ namespace UnityNaturalMCP.Tests.McpTools.RunTestsTool
             var failed = new FakeTestResultAdaptor
             {
                 TestStatus = TestStatus.Failed,
+                Name = "FailedTest",
                 FullName = "Fake.FailedTest",
+                ResultState = "Failed:Error",
+                Duration = 1.23d,
                 Message = "Message of Fake.FailedTest",
-                StackTrace = "Stack trace of Fake.FailedTest"
+                StackTrace = "Stack trace of Fake.FailedTest",
+                Output = "Output of Fake.FailedTest"
             };
 
             var sut = new TestResultCollector();
@@ -71,11 +75,8 @@ namespace UnityNaturalMCP.Tests.McpTools.RunTestsTool
             sut.TestFinished(failed); // twice
 
             Assert.That(sut._testResults.failCount, Is.EqualTo(2));
-            Assert.That(sut._testResults.failedTests, Is.EqualTo(new[]
-            {
-                "Test Fake.FailedTest is failed with message: Message of Fake.FailedTest\nStack trace of Fake.FailedTest",
-                "Test Fake.FailedTest is failed with message: Message of Fake.FailedTest\nStack trace of Fake.FailedTest"
-            }));
+            Assert.That(sut._testResults.ToJson(), Is.EqualTo(
+                "{\"failCount\":2,\"passCount\":0,\"skipCount\":0,\"inconclusiveCount\":0,\"failedTests\":[{\"name\":\"FailedTest\",\"fullName\":\"Fake.FailedTest\",\"resultState\":\"Failed:Error\",\"testStatus\":\"Failed\",\"duration\":1.23,\"message\":\"Message of Fake.FailedTest\",\"stackTrace\":\"Stack trace of Fake.FailedTest\",\"output\":\"Output of Fake.FailedTest\"},{\"name\":\"FailedTest\",\"fullName\":\"Fake.FailedTest\",\"resultState\":\"Failed:Error\",\"testStatus\":\"Failed\",\"duration\":1.23,\"message\":\"Message of Fake.FailedTest\",\"stackTrace\":\"Stack trace of Fake.FailedTest\",\"output\":\"Output of Fake.FailedTest\"}],\"success\":false}"));
         }
 
         [Test]
@@ -84,9 +85,13 @@ namespace UnityNaturalMCP.Tests.McpTools.RunTestsTool
             var inconclusive = new FakeTestResultAdaptor
             {
                 TestStatus = TestStatus.Inconclusive,
+                Name = "InconclusiveTest",
                 FullName = "Fake.InconclusiveTest",
+                ResultState = "Inconclusive",
+                Duration = 1.23d,
                 Message = "Message of Fake.InconclusiveTest",
-                StackTrace = "Stack trace of Fake.InconclusiveTest"
+                StackTrace = "Stack trace of Fake.InconclusiveTest",
+                Output = "Output of Fake.InconclusiveTest"
             };
 
             var sut = new TestResultCollector();
@@ -94,11 +99,8 @@ namespace UnityNaturalMCP.Tests.McpTools.RunTestsTool
             sut.TestFinished(inconclusive); // twice
 
             Assert.That(sut._testResults.inconclusiveCount, Is.EqualTo(2));
-            Assert.That(sut._testResults.failedTests, Is.EqualTo(new[]
-            {
-                "Test Fake.InconclusiveTest is failed with message: Message of Fake.InconclusiveTest\nStack trace of Fake.InconclusiveTest",
-                "Test Fake.InconclusiveTest is failed with message: Message of Fake.InconclusiveTest\nStack trace of Fake.InconclusiveTest"
-            }));
+            Assert.That(sut._testResults.ToJson(), Is.EqualTo(
+                "{\"failCount\":0,\"passCount\":0,\"skipCount\":0,\"inconclusiveCount\":2,\"failedTests\":[{\"name\":\"InconclusiveTest\",\"fullName\":\"Fake.InconclusiveTest\",\"resultState\":\"Inconclusive\",\"testStatus\":\"Inconclusive\",\"duration\":1.23,\"message\":\"Message of Fake.InconclusiveTest\",\"stackTrace\":\"Stack trace of Fake.InconclusiveTest\",\"output\":\"Output of Fake.InconclusiveTest\"},{\"name\":\"InconclusiveTest\",\"fullName\":\"Fake.InconclusiveTest\",\"resultState\":\"Inconclusive\",\"testStatus\":\"Inconclusive\",\"duration\":1.23,\"message\":\"Message of Fake.InconclusiveTest\",\"stackTrace\":\"Stack trace of Fake.InconclusiveTest\",\"output\":\"Output of Fake.InconclusiveTest\"}],\"success\":false}"));
         }
 
         [Test]


### PR DESCRIPTION
Fix the failed test details in the response.

### Before
Failed test details as a string.
e.g.,
```
Test Fake.FailedTest is failed with message: Message of Fake.FailedTest
Stack trace of Fake.FailedTest
```

### After
Failed test details in JSON format.
e.g.,
```
{
  "name":"FailedTest",
  "fullName":"Fake.FailedTest",
  "resultState":"Failed:Error",
  "testStatus":"Failed",
  "duration":1.23,
  "message":"Message of Fake.FailedTest",
  "stackTrace":"Stack trace of Fake.FailedTest",
  "output":"Output of Fake.FailedTest"
}
```

refs #73 