### PR TITLE
Fix to return test failure if there are no filter results

### DIFF
--- a/UnityNaturalMCPServer/Editor/McpTools/RunTestsTool/TestResultCollector.cs
+++ b/UnityNaturalMCPServer/Editor/McpTools/RunTestsTool/TestResultCollector.cs
@@ -14,13 +14,14 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
         [SuppressMessage("ReSharper", "InconsistentNaming")]
         internal readonly TestResults _testResults = new TestResults();
 
+        private string _rootSuiteName;
         private string _abortMessage;
         private bool _runFinished;
 
         /// <inheritdoc/>
         public void RunStarted(ITestAdaptor testsToRun)
         {
-            // nop
+            _rootSuiteName = testsToRun.FullName;
         }
 
         /// <inheritdoc/>
@@ -40,7 +41,12 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
         {
             if (result.HasChildren)
             {
-                return;
+                return; // Exclude test suites.
+            }
+
+            if (result.FullName == _rootSuiteName)
+            {
+                return; // Note: When the filter result is 0, the "Passed" node with the same name as the project name is included, so exclude it.
             }
 
             switch (result.TestStatus)

--- a/UnityNaturalMCPServer/Editor/McpTools/RunTestsTool/TestResults.cs
+++ b/UnityNaturalMCPServer/Editor/McpTools/RunTestsTool/TestResults.cs
@@ -37,7 +37,7 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
         /// <summary>
         /// Returns true if all tests passed.
         /// </summary>
-        public bool success => (failCount + inconclusiveCount) == 0;
+        public bool success => (failCount + inconclusiveCount) == 0 && passCount > 0;
 
         /// <summary>
         /// Returns a JSON representation of the test results.

--- a/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/FakeTestAdaptor.cs
+++ b/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/FakeTestAdaptor.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using NUnit.Framework.Interfaces;
+using UnityEditor.TestTools.TestRunner.Api;
+using RunState = UnityEditor.TestTools.TestRunner.Api.RunState;
+
+namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
+{
+    public class FakeTestAdaptor : ITestAdaptor
+    {
+        public string Id { get; }
+        public string Name { get; }
+        public string FullName { get; set; }
+        public int TestCaseCount { get; }
+        public bool HasChildren { get; }
+        public bool IsSuite { get; }
+        public IEnumerable<ITestAdaptor> Children { get; }
+        public ITestAdaptor Parent { get; }
+        public int TestCaseTimeout { get; }
+        public ITypeInfo TypeInfo { get; }
+        public IMethodInfo Method { get; }
+        public object[] Arguments { get; }
+        public string[] Categories { get; }
+        public bool IsTestAssembly { get; }
+        public RunState RunState { get; }
+        public string Description { get; }
+        public string SkipReason { get; }
+        public string ParentId { get; }
+        public string ParentFullName { get; }
+        public string UniqueName { get; }
+        public string ParentUniqueName { get; }
+        public int ChildIndex { get; }
+        public TestMode TestMode { get; }
+    }
+}

--- a/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/FakeTestAdaptor.cs.meta
+++ b/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/FakeTestAdaptor.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 99f22d85d8f944b5bc2f2e308af93272
+timeCreated: 1751103610

--- a/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/FakeTestResultAdaptor.cs
+++ b/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/FakeTestResultAdaptor.cs
@@ -5,7 +5,7 @@ using NUnit.Framework.Interfaces;
 using UnityEditor.TestTools.TestRunner.Api;
 using TestStatus = UnityEditor.TestTools.TestRunner.Api.TestStatus;
 
-namespace UnityNaturalMCP.Tests.McpTools.RunTestsTool
+namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
 {
     [SuppressMessage("ReSharper", "UnassignedGetOnlyAutoProperty")]
     public class FakeTestResultAdaptor : ITestResultAdaptor

--- a/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/TestResultCollectorTest.cs
+++ b/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/TestResultCollectorTest.cs
@@ -9,6 +9,15 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
     [TestFixture]
     public class TestResultCollectorTest
     {
+        private const string RootTestSuiteFullName = "UnityNaturalMCP";
+
+        private static TestResultCollector CreateTestResultCollector()
+        {
+            var sut = new TestResultCollector();
+            sut.RunStarted(new FakeTestAdaptor { FullName = RootTestSuiteFullName });
+            return sut;
+        }
+
         [Test]
         public void TestFinished_HasChildren_NotCountedUp()
         {
@@ -18,7 +27,22 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
                 TestStatus = TestStatus.Passed
             };
 
-            var sut = new TestResultCollector();
+            var sut = CreateTestResultCollector();
+            sut.TestFinished(hasChildren);
+
+            Assert.That(sut._testResults.passCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestFinished_SameFullNameAsRootTestSuite_NotCountedUp()
+        {
+            var hasChildren = new FakeTestResultAdaptor
+            {
+                FullName = RootTestSuiteFullName,
+                TestStatus = TestStatus.Passed
+            };
+
+            var sut = CreateTestResultCollector();
             sut.TestFinished(hasChildren);
 
             Assert.That(sut._testResults.passCount, Is.EqualTo(0));
@@ -32,7 +56,7 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
                 TestStatus = TestStatus.Passed
             };
 
-            var sut = new TestResultCollector();
+            var sut = CreateTestResultCollector();
             sut.TestFinished(passed);
             sut.TestFinished(passed); // twice
 
@@ -47,7 +71,7 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
                 TestStatus = TestStatus.Skipped
             };
 
-            var sut = new TestResultCollector();
+            var sut = CreateTestResultCollector();
             sut.TestFinished(skipped);
             sut.TestFinished(skipped); // twice
 
@@ -69,7 +93,7 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
                 Output = "Output of Fake.FailedTest"
             };
 
-            var sut = new TestResultCollector();
+            var sut = CreateTestResultCollector();
             sut.TestFinished(failed);
             sut.TestFinished(failed); // twice
 
@@ -93,7 +117,7 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
                 Output = "Output of Fake.InconclusiveTest"
             };
 
-            var sut = new TestResultCollector();
+            var sut = CreateTestResultCollector();
             sut.TestFinished(inconclusive);
             sut.TestFinished(inconclusive); // twice
 
@@ -106,7 +130,7 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
         [Timeout(5000)]
         public async Task WaitForRunFinished_RunFinished_LeaveAwaiting()
         {
-            var sut = new TestResultCollector();
+            var sut = CreateTestResultCollector();
             sut.RunFinished(null);
 
             var result = await sut.WaitForRunFinished();
@@ -118,7 +142,7 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
         public async Task WaitForRunFinished_OnError_LeaveAwaiting()
         {
             var message = "Error occurred!";
-            var sut = new TestResultCollector();
+            var sut = CreateTestResultCollector();
             sut.OnError(message);
 
             var result = await sut.WaitForRunFinished();
@@ -129,7 +153,7 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
         [Timeout(5000)]
         public async Task WaitForRunFinished_Cancel_LeaveAwaiting()
         {
-            var sut = new TestResultCollector();
+            var sut = CreateTestResultCollector();
             var cts = new CancellationTokenSource();
             cts.CancelAfter(1000);
 

--- a/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/TestResultCollectorTest.cs
+++ b/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/TestResultCollectorTest.cs
@@ -3,9 +3,8 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using UnityEditor.TestTools.TestRunner.Api;
 using UnityEngine;
-using UnityNaturalMCP.Editor.McpTools.RunTestsTool;
 
-namespace UnityNaturalMCP.Tests.McpTools.RunTestsTool
+namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
 {
     [TestFixture]
     public class TestResultCollectorTest

--- a/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/TestResultsTest.cs
+++ b/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/TestResultsTest.cs
@@ -1,7 +1,6 @@
 using NUnit.Framework;
-using UnityNaturalMCP.Editor.McpTools.RunTestsTool;
 
-namespace UnityNaturalMCP.Tests.McpTools.RunTestsTool
+namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
 {
     [TestFixture]
     public class TestResultsTest

--- a/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/TestResultsTest.cs
+++ b/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/TestResultsTest.cs
@@ -10,7 +10,8 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
         {
             var sut = new TestResults
             {
-                failCount = 1
+                failCount = 1,
+                passCount = 1, // Does not affect the actual
             };
 
             Assert.That(sut.success, Is.False);
@@ -21,18 +22,34 @@ namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
         {
             var sut = new TestResults
             {
-                inconclusiveCount = 1
+                inconclusiveCount = 1,
+                passCount = 1, // Does not affect the actual
             };
 
             Assert.That(sut.success, Is.False);
         }
 
         [Test]
-        public void Success_WithoutFailOrInconclusive_ReturnsTrue()
+        public void Success_WithoutPass_ReturnsFalse()
         {
             var sut = new TestResults
             {
                 failCount = 0,
+                passCount = 0,
+                skipCount = 1, // Note: Does not affect the actual
+                inconclusiveCount = 0
+            };
+
+            Assert.That(sut.success, Is.False);
+        }
+
+        [Test]
+        public void Success_WithPassAndWithoutFailOrInconclusive_ReturnsTrue()
+        {
+            var sut = new TestResults
+            {
+                failCount = 0,
+                passCount = 1,
                 inconclusiveCount = 0
             };
 


### PR DESCRIPTION
### Problem

Returns test success if there are no filter results.

### Cause

One "passed" node is included if there are no filter results.
This node name matches the project name.

### Fixes

Exclude node name matches the project name.