### PR TITLE
Fix cancellation handling in RunTestsTools

### DIFF
--- a/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/RunTestsToolTest.cs
+++ b/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/RunTestsToolTest.cs
@@ -1,0 +1,47 @@
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace UnityNaturalMCP.Editor.McpTools.RunTestsTool
+{
+    [TestFixture]
+    public class RunTestsToolTest
+    {
+        private const string NotExistCategoryName = "Dummy";
+        private const string CanceledMessage = "A task was canceled.";
+
+        [Test]
+        public async Task RunEditModeTests_TaskCancel_CancelledTestRun()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource();
+
+            var testTask = RunTestsTool.RunEditModeTests(
+                categoryNames: new[] { NotExistCategoryName },
+                cancellationToken: cancellationTokenSource.Token);
+
+            await Task.Yield();
+            cancellationTokenSource.Cancel();
+
+            await testTask;
+            LogAssert.Expect(LogType.Warning, CanceledMessage);
+        }
+
+        [Test]
+        public async Task RunPlayModeTests_TaskCancel_CancelledTestRun()
+        {
+            using var cancellationTokenSource = new CancellationTokenSource();
+
+            var testTask = RunTestsTool.RunPlayModeTests(
+                categoryNames: new[] { NotExistCategoryName },
+                cancellationToken: cancellationTokenSource.Token);
+
+            await Task.Yield();
+            cancellationTokenSource.Cancel();
+
+            await testTask;
+            LogAssert.Expect(LogType.Warning, CanceledMessage);
+        }
+    }
+}

--- a/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/RunTestsToolTest.cs.meta
+++ b/UnityNaturalMCPServer/Tests/McpTools/RunTestsTool/RunTestsToolTest.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 9dbbdebda5a7412488c9500586a9b07d
+timeCreated: 1751559427


### PR DESCRIPTION
### Problem

Cancellation is not working in `RunEditModeTests` and `RunPlayModeTests` tools.

### Fixes

- Fix cancellation handling.
- Add tests for cancellation.